### PR TITLE
Fixed RemovedInDjango110Warning: django.conf.urls.patterns() is depre…

### DIFF
--- a/foundation/urls.py
+++ b/foundation/urls.py
@@ -1,8 +1,8 @@
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 from django.views.generic import TemplateView
 
 # Test patern, renders Zurb Foundation default page using base template
-urlpatterns = patterns('',
+urlpatterns = [
     url(regex=r'^$',
         view=TemplateView.as_view(template_name="foundation/index.html"),
         name="foundation_index"),
@@ -14,4 +14,4 @@ urlpatterns = patterns('',
     url(regex=r'^icons/$',
         view=TemplateView.as_view(template_name="foundation/icons.html"),
         name="foundation_icons"),
-)
+]


### PR DESCRIPTION
Fixes the following warning:
RemovedInDjango110Warning: django.conf.urls.patterns() is deprecated and will be removed in Django 1.10. Update your urlpatterns to be a list of django.conf.urls.url() instances instead.
